### PR TITLE
🌟 feat: 우정의 숲 날짜별 일기 조회 구현

### DIFF
--- a/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
@@ -1,8 +1,8 @@
-package com.x1.groo.mate.command.application.controller;
+package com.x1.groo.forest.mate.command.application.controller;
 
 import com.x1.groo.common.JwtUtil;
-import com.x1.groo.mate.command.application.service.CommandMateService;
-import com.x1.groo.mate.command.domain.vo.CreateInviteRequest;
+import com.x1.groo.forest.mate.command.application.service.CommandMateService;
+import com.x1.groo.forest.mate.command.domain.vo.CreateInviteRequest;
 import io.jsonwebtoken.Claims;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -35,7 +35,6 @@ public class CommandMateController {
         String inviteLink = "https://localhost:8080/mate/invite/" + inviteCode;
         return new CreateInviteRequest(inviteLink);
     }
-
 
 
 }

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
@@ -1,4 +1,4 @@
-package com.x1.groo.mate.command.application.service;
+package com.x1.groo.forest.mate.command.application.service;
 
 public interface CommandMateService {
     String createInviteLink(int forestId);

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateServiceImpl.java
@@ -1,4 +1,4 @@
-package com.x1.groo.mate.command.application.service;
+package com.x1.groo.forest.mate.command.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -16,7 +16,6 @@ public class CommandMateServiceImpl implements CommandMateService {
 
     @Override
     public String createInviteLink(int forestId) {
-
 
 
         // 초대 링크 생성 로직 작성

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/vo/CreateInviteRequest.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/vo/CreateInviteRequest.java
@@ -1,4 +1,4 @@
-package com.x1.groo.mate.command.domain.vo;
+package com.x1.groo.forest.mate.command.domain.vo;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/x1/groo/forest/mate/query/controller/MateController.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/controller/MateController.java
@@ -1,0 +1,37 @@
+package com.x1.groo.forest.mate.query.controller;
+
+import com.x1.groo.common.JwtUtil;
+import com.x1.groo.forest.mate.query.dto.DiaryByDateDTO;
+import com.x1.groo.forest.mate.query.service.MateServiceImpl;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/mate")
+@RequiredArgsConstructor
+public class MateController {
+
+    private final MateServiceImpl mateService;
+    private final JwtUtil jwtUtil;   // JwtUtil 주입 추가
+
+    @GetMapping("/diary/{forestId}/date")
+    public ResponseEntity<List<DiaryByDateDTO>> getDiariesByDate(
+            @RequestHeader(value = "Authorization") String authorizationHeader,
+            @PathVariable int forestId,
+            @RequestParam LocalDate date
+    ) {
+        // JWT에서 userId 추출
+        String token = authorizationHeader.replace("Bearer", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        // 서비스 호출
+        List<DiaryByDateDTO> diaries = mateService.findDiaries(userId, forestId, date);
+        return ResponseEntity.ok(diaries);
+    }
+}

--- a/src/main/java/com/x1/groo/forest/mate/query/dao/MateMapper.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/dao/MateMapper.java
@@ -1,0 +1,23 @@
+package com.x1.groo.forest.mate.query.dao;
+
+import com.x1.groo.forest.mate.query.dto.DiaryByDateDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper
+public interface MateMapper {
+
+    List<DiaryByDateDTO> findDiaryByDateAndForestId(
+            @Param("forestId") int forestId,
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
+
+    // userId가 forestId에 있는지 확인
+    boolean existsUserInForest(@Param("userId") int userId, @Param("forestId") int forestId);
+}
+
+

--- a/src/main/java/com/x1/groo/forest/mate/query/dto/DiaryByDateDTO.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/dto/DiaryByDateDTO.java
@@ -1,0 +1,19 @@
+package com.x1.groo.forest.mate.query.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class DiaryByDateDTO {
+    private String nickname;            // 일기를 작성한 유저의 닉네임
+    private String content;             // 일기의 내용
+    private LocalDateTime createdAt;    // 일기 작성 날짜 + 시간
+}

--- a/src/main/java/com/x1/groo/forest/mate/query/service/MateService.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/service/MateService.java
@@ -1,0 +1,10 @@
+package com.x1.groo.forest.mate.query.service;
+
+import com.x1.groo.forest.mate.query.dto.DiaryByDateDTO;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MateService {
+    List<DiaryByDateDTO> findDiaries(int userId, int forestId, LocalDate date);
+}

--- a/src/main/java/com/x1/groo/forest/mate/query/service/MateServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/service/MateServiceImpl.java
@@ -1,0 +1,34 @@
+package com.x1.groo.forest.mate.query.service;
+
+import com.x1.groo.forest.mate.query.dao.MateMapper;
+import com.x1.groo.forest.mate.query.dto.DiaryByDateDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MateServiceImpl implements MateService {
+
+    private final MateMapper mateMapper;
+
+    @Override
+    public List<DiaryByDateDTO> findDiaries(int userId, int forestId, LocalDate date) {
+
+        // userId가 forestId에 속하는지 확인
+        if (!mateMapper.existsUserInForest(userId, forestId)) {
+            throw new IllegalArgumentException("해당 숲에 접근 권한이 없습니다.");
+        }
+
+        // 날짜 범위 생성
+        LocalDateTime startDateTime = date.atStartOfDay();      // 00:00:00
+        LocalDateTime endDateTime = date.atTime(23, 59, 59);    // 23:59:59
+
+        // 일기 리스트 조회
+        return mateMapper.findDiaryByDateAndForestId(forestId, startDateTime, endDateTime);
+    }
+}
+

--- a/src/main/resources/com/x1/groo/forest/mate/query/dao/MateMapper.xml
+++ b/src/main/resources/com/x1/groo/forest/mate/query/dao/MateMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.x1.groo.forest.mate.query.dao.MateMapper">
+	
+	<select id="findDiaryByDateAndForestId" resultType="com.x1.groo.forest.mate.query.dto.DiaryByDateDTO">
+		SELECT
+			   u.nickname
+		     , d.content
+		     , d.created_at AS createdAt
+		  FROM diary d
+		  JOIN user u ON d.user_id = u.id
+		  JOIN forest f ON d.forest_id = f.id
+		  LEFT JOIN shared_forest sf ON f.id = sf.id
+		 WHERE f.id = #{forestId}
+		   AND d.created_at BETWEEN #{startDateTime} AND #{endDateTime}
+	</select>
+    
+    <!-- 추가: userId가 해당 forestId에 속해있는지 확인하는 쿼리 -->
+    <select id="existsUserInForest" resultType="boolean">
+        SELECT
+			   CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+          FROM shared_forest
+	     WHERE user_id = #{userId}
+           AND forest_id = #{forestId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #5 

## ✅ 작업 사항
- 우정의 숲에서 날짜별 일기 조회 구현하였습니다 
- 유저들이 작성한 일기는 해당 우정의 숲에 들어가있는 모든 유저가 확인할 수 있습니다 !

- mate 패키지 구조 잘못된 것 수정해서 같이 올렸습니다 

## 📸 스크린샷 (선택)
<img width="682" alt="image" src="https://github.com/user-attachments/assets/467b2bdc-2350-41a0-a608-bb15ce24cd5c" />


## 👩‍💻 공유 포인트 및 논의 사항
