### PR TITLE
🔨 refactor: Security 인증 실패/권한 실패 예외 수정

### DIFF
--- a/src/main/java/com/x1/groo/forest/mate/query/service/MateServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/service/MateServiceImpl.java
@@ -3,6 +3,7 @@ package com.x1.groo.forest.mate.query.service;
 import com.x1.groo.forest.mate.query.dao.MateMapper;
 import com.x1.groo.forest.mate.query.dto.DiaryByDateDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -20,7 +21,7 @@ public class MateServiceImpl implements MateService {
 
         // userId가 forestId에 속하는지 확인
         if (!mateMapper.existsUserInForest(userId, forestId)) {
-            throw new IllegalArgumentException("해당 숲에 접근 권한이 없습니다.");
+            throw new AccessDeniedException("해당 숲에 대한 접근 권한이 없습니다.");
         }
 
         // 날짜 범위 생성

--- a/src/main/java/com/x1/groo/security/config/SecurityConfig.java
+++ b/src/main/java/com/x1/groo/security/config/SecurityConfig.java
@@ -28,7 +28,6 @@ public class SecurityConfig {
     private final CorsFilter corsFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-    private final UserDetailsService userDetailsService;
 
     // JwtFilter 를 빈으로 등록
     @Bean

--- a/src/main/java/com/x1/groo/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/x1/groo/security/jwt/JwtAccessDeniedHandler.java
@@ -1,20 +1,37 @@
 package com.x1.groo.security.jwt;
 
-import jakarta.servlet.ServletException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
-@Component
-public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
+// 인가 실패(권한 문제) - 403
+@Component
+@Slf4j
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response,
-                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        // 필요한 권한이 없이 접근하려 할때 403
-        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+            throws IOException {
+
+        log.error("Authorization error: {}", accessDeniedException.getMessage());
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", HttpServletResponse.SC_FORBIDDEN);
+        body.put("error", "Forbidden");
+        body.put("message", "접근 권한이 없습니다.");
+        body.put("path", request.getRequestURI());
+
+        new ObjectMapper().writeValue(response.getWriter(), body);
     }
 }
+

--- a/src/main/java/com/x1/groo/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/x1/groo/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,30 +1,36 @@
 package com.x1.groo.security.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-@Slf4j
-@Component
-public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
+// 인증 실패(토큰 문재) - 401
+@Component
+@Slf4j
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response,
-                         AuthenticationException authException)
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
             throws IOException {
-        log.error(authException.getMessage(), authException);
-        if (authException instanceof InsufficientAuthenticationException) {
-            // 인증에 부족한 부분이 있을 경우
-            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Access Denied");
-        } else {
-            // 인증 실패 시 기본적으로 401 반환
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized Access");
-        }
+
+        log.error("Authentication error: {}", authException.getMessage());
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+        body.put("error", "Unauthorized");
+        body.put("message", "인증이 필요합니다. (토큰이 없거나 만료되었습니다)");
+        body.put("path", request.getRequestURI());
+
+        new ObjectMapper().writeValue(response.getWriter(), body);
     }
 }


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #16 

## ✅ 작업 사항

- 사용자가 숲에 속해있는지 검증하는 로직 추가
- 인증 실패 시 401 Unauthorized, 권한 실패 시 403 Forbidden 반환
- AccessDeniedException 사용하여 권한 에러 명확히 처리

## 📸 스크린샷 (선택)
<img width="675" alt="image" src="https://github.com/user-attachments/assets/5c1d1b1e-63cf-4118-9a99-1f43c2ab8415" />
<img width="678" alt="image" src="https://github.com/user-attachments/assets/144d58d0-09cf-41ad-b7ab-9f465524fec3" />


## 👩‍💻 공유 포인트 및 논의 사항
