### PR TITLE
🚑 fix: 방명록 리스트 조회용 DTO 추가 및 Controller 코드 수정

### DIFF
--- a/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
@@ -3,6 +3,7 @@ package com.x1.groo.forest.emotion.query.controller;
 import com.x1.groo.common.JwtUtil;
 import com.x1.groo.forest.emotion.command.application.service.CommandEmotionForestService;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import com.x1.groo.forest.emotion.query.service.QueryForestEmotionService;
 import io.jsonwebtoken.Claims;
@@ -26,8 +27,7 @@ public class QueryForestEmotionController {
     private final QueryForestEmotionService queryForestEmotionService;
 
     @Autowired
-    public QueryForestEmotionController(JwtUtil jwtUtil, QueryForestEmotionService queryForestEmotionService,
-                                        CommandEmotionForestService commandEmotionForestService) {
+    public QueryForestEmotionController(JwtUtil jwtUtil, QueryForestEmotionService queryForestEmotionService) {
         this.jwtUtil = jwtUtil;
         this.queryForestEmotionService = queryForestEmotionService;
     }
@@ -55,33 +55,16 @@ public class QueryForestEmotionController {
 
     // 감정의 숲에 작성된 방명록 리스트 조회
     @GetMapping("/mailbox-lists/{forestId}")
-    public ResponseEntity<List<QueryForestEmotionMailboxDTO>> getMailboxList(
-            @RequestHeader(value = "Authorization") String authorizationHeader,
-            @PathVariable int forestId) {
-        String token = authorizationHeader.replace("Bearer", "").trim();
-        Claims claims = jwtUtil.parseJwt(token);
-        int userId = ((Number) claims.get("userId")).intValue();
+    public List<QueryForestEmotionMailboxListDTO> getMailboxList(@PathVariable int forestId) {
 
-        log.info("userId = {}", userId);
-
-        List<QueryForestEmotionMailboxDTO> mailboxList = queryForestEmotionService.getMailboxList(userId, forestId);
-
-        return ResponseEntity.ok(mailboxList);
+        return queryForestEmotionService.getMailboxList(forestId);
     }
 
 
     @GetMapping("/mailbox-detail/{id}")
-    public ResponseEntity<List<QueryForestEmotionMailboxDTO>> getMailboxDetail (
-            @RequestHeader (value = "Authorization") String authorizationHeader,
-            @PathVariable int id) {
-        String token = authorizationHeader.replace("Bearer", "").trim();
-        Claims claims = jwtUtil.parseJwt(token);
-        int userId = ((Number) claims.get("userId")).intValue();
+    public List<QueryForestEmotionMailboxDTO> getMailboxDetail(@PathVariable int id) {
 
-        log.info("userId = {}", userId);
-
-        List<QueryForestEmotionMailboxDTO> mailboxDetail = queryForestEmotionService.getMailboxDetail(userId, id);
-        return ResponseEntity.ok(mailboxDetail);
+        return queryForestEmotionService.getMailboxDetail(id);
     }
 
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
@@ -9,6 +9,7 @@ import io.jsonwebtoken.Claims;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,7 +34,7 @@ public class QueryForestEmotionController {
 
     // 사용자가 보유한 기억의 조각 카테고리별 조회
     @GetMapping("/items/{categoryId}")
-    public ResponseEntity<List<QueryForestEmotionUserItemDTO>> getItems(
+    public ResponseEntity<?> getItems(
             @RequestHeader(value = "Authorization") String authorizationHeader,
             @PathVariable int categoryId) {
         String token = authorizationHeader.replace("Bearer", "").trim();
@@ -43,6 +44,11 @@ public class QueryForestEmotionController {
         log.info("userId = {}", userId);
 
         List<QueryForestEmotionUserItemDTO> items = queryForestEmotionService.getPieceOfMemory(userId, categoryId);
+
+        if (items == null || items.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("보유한 기억의 조각이 없습니다. 일기를 써서 더 많은 조각들을 모아봐요🌸");
+        }
 
         return ResponseEntity.ok(items);
     }

--- a/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
@@ -1,26 +1,81 @@
 package com.x1.groo.forest.emotion.query.controller;
 
+import com.x1.groo.common.JwtUtil;
+import com.x1.groo.forest.emotion.command.application.service.CommandEmotionForestService;
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import com.x1.groo.forest.emotion.query.service.QueryForestEmotionService;
+import io.jsonwebtoken.Claims;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/items")
+@RequestMapping
+@Slf4j
 public class QueryForestEmotionController {
 
+    private final JwtUtil jwtUtil;
+    private final QueryForestEmotionService queryForestEmotionService;
+
     @Autowired
-    private QueryForestEmotionService queryForestEmotionService;
+    public QueryForestEmotionController(JwtUtil jwtUtil, QueryForestEmotionService queryForestEmotionService,
+                                        CommandEmotionForestService commandEmotionForestService) {
+        this.jwtUtil = jwtUtil;
+        this.queryForestEmotionService = queryForestEmotionService;
+    }
 
     // 사용자가 보유한 기억의 조각 카테고리별 조회
-    @GetMapping("/{userId}/{categoryId}")
-    public List<QueryForestEmotionUserItemDTO> getItems(
-            @PathVariable int userId,
+    @GetMapping("/items/{categoryId}")
+    public ResponseEntity<List<QueryForestEmotionUserItemDTO>> getItems(
+            @RequestHeader(value = "Authorization") String authorizationHeader,
             @PathVariable int categoryId) {
-        return queryForestEmotionService.getPieceOfMemory(userId, categoryId);
+        String token = authorizationHeader.replace("Bearer", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        log.info("userId = {}", userId);
+
+        List<QueryForestEmotionUserItemDTO> items = queryForestEmotionService.getPieceOfMemory(userId, categoryId);
+
+        return ResponseEntity.ok(items);
     }
+
+    // 감정의 숲에 작성된 방명록 리스트 조회
+    @GetMapping("/mailbox-lists/{forestId}")
+    public ResponseEntity<List<QueryForestEmotionMailboxDTO>> getMailboxList(
+            @RequestHeader(value = "Authorization") String authorizationHeader,
+            @PathVariable int forestId) {
+        String token = authorizationHeader.replace("Bearer", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        log.info("userId = {}", userId);
+
+        List<QueryForestEmotionMailboxDTO> mailboxList = queryForestEmotionService.getMailboxList(userId, forestId);
+
+        return ResponseEntity.ok(mailboxList);
+    }
+
+
+    @GetMapping("/mailbox-detail/{id}")
+    public ResponseEntity<List<QueryForestEmotionMailboxDTO>> getMailboxDetail (
+            @RequestHeader (value = "Authorization") String authorizationHeader,
+            @PathVariable int id) {
+        String token = authorizationHeader.replace("Bearer", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        log.info("userId = {}", userId);
+
+        List<QueryForestEmotionMailboxDTO> mailboxDetail = queryForestEmotionService.getMailboxDetail(userId, id);
+        return ResponseEntity.ok(mailboxDetail);
+    }
+
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionMailboxDTO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionMailboxDTO.java
@@ -1,0 +1,20 @@
+package com.x1.groo.forest.emotion.query.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class QueryForestEmotionMailboxDTO {
+
+    private int id;
+    private String contents;
+    private LocalDateTime createdAt;
+    private int forestId;
+    private int userId;
+    private Boolean isDeleted;
+
+}

--- a/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionMailboxListDTO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionMailboxListDTO.java
@@ -8,12 +8,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class QueryForestEmotionMailboxDTO {
-
+public class QueryForestEmotionMailboxListDTO {
     private int id;
-    private String content;
     private LocalDateTime createdAt;
     private int forestId;
-    private int userId;
-
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionUserItemDTO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionUserItemDTO.java
@@ -16,4 +16,5 @@ public class QueryForestEmotionUserItemDTO {
     private String itemName;
     private int categoryId;
     private String imageUrl;
+
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
@@ -1,5 +1,6 @@
 package com.x1.groo.forest.emotion.query.repository;
 
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
@@ -9,8 +10,18 @@ import org.apache.ibatis.annotations.Param;
 public interface QueryForestEmotionMapper {
 
     // 사용자가 보유한 기억의 조각 카테고리별 조회
-    List<QueryForestEmotionUserItemDTO> findPieceOfMemory(
-            @Param("userId") int id,
-            @Param("categoryId") int category
+    List<QueryForestEmotionUserItemDTO> findPieceOfMemory (
+            @Param("userId") int userId,
+            @Param("categoryId") int categoryId
             );
+
+    List<QueryForestEmotionMailboxDTO> findMailboxList (
+            @Param("userId") int userId,
+            @Param("forestId") int forestId
+            );
+
+    List<QueryForestEmotionMailboxDTO> findMailboxDetail (
+            @Param("userId") int userId,
+            @Param("mailbox") int id
+    );
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
@@ -1,6 +1,7 @@
 package com.x1.groo.forest.emotion.query.repository;
 
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
@@ -10,18 +11,16 @@ import org.apache.ibatis.annotations.Param;
 public interface QueryForestEmotionMapper {
 
     // 사용자가 보유한 기억의 조각 카테고리별 조회
-    List<QueryForestEmotionUserItemDTO> findPieceOfMemory (
+    List<QueryForestEmotionUserItemDTO> findPieceOfMemory(
             @Param("userId") int userId,
             @Param("categoryId") int categoryId
             );
 
-    List<QueryForestEmotionMailboxDTO> findMailboxList (
-            @Param("userId") int userId,
+    List<QueryForestEmotionMailboxListDTO> findMailboxList(
             @Param("forestId") int forestId
             );
 
-    List<QueryForestEmotionMailboxDTO> findMailboxDetail (
-            @Param("userId") int userId,
-            @Param("mailbox") int id
+    List<QueryForestEmotionMailboxDTO> findMailboxDetail(
+            @Param("id") int id
     );
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
@@ -1,9 +1,14 @@
 package com.x1.groo.forest.emotion.query.service;
 
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import java.util.List;
 
 public interface QueryForestEmotionService {
     List<QueryForestEmotionUserItemDTO> getPieceOfMemory(int userId, int categoryId);
+
+    List<QueryForestEmotionMailboxDTO> getMailboxList(int userId, int forestId);
+
+    List<QueryForestEmotionMailboxDTO> getMailboxDetail(int userId, int id);
 }
 

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
@@ -1,14 +1,15 @@
 package com.x1.groo.forest.emotion.query.service;
 
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import java.util.List;
 
 public interface QueryForestEmotionService {
     List<QueryForestEmotionUserItemDTO> getPieceOfMemory(int userId, int categoryId);
 
-    List<QueryForestEmotionMailboxDTO> getMailboxList(int userId, int forestId);
+    List<QueryForestEmotionMailboxListDTO> getMailboxList(int forestId);
 
-    List<QueryForestEmotionMailboxDTO> getMailboxDetail(int userId, int id);
+    List<QueryForestEmotionMailboxDTO> getMailboxDetail(int id);
 }
 

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
@@ -1,6 +1,7 @@
 package com.x1.groo.forest.emotion.query.service;
 
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import com.x1.groo.forest.emotion.query.repository.QueryForestEmotionMapper;
 import java.util.List;
@@ -18,12 +19,12 @@ public class QueryForestEmotionServiceImpl implements QueryForestEmotionService 
         return queryForestEmotionMapper.findPieceOfMemory(userId, categoryId);
     }
 
-    public List<QueryForestEmotionMailboxDTO> getMailboxList (int userId, int forestId) {
-        return queryForestEmotionMapper.findMailboxList(userId, forestId);
+    public List<QueryForestEmotionMailboxListDTO> getMailboxList (int forestId) {
+        return queryForestEmotionMapper.findMailboxList(forestId);
     }
 
-    public List<QueryForestEmotionMailboxDTO> getMailboxDetail (int userId, int id) {
-        return queryForestEmotionMapper.findMailboxDetail(userId, id);
+    public List<QueryForestEmotionMailboxDTO> getMailboxDetail (int id) {
+        return queryForestEmotionMapper.findMailboxDetail(id);
     }
 
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.x1.groo.forest.emotion.query.service;
 
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import com.x1.groo.forest.emotion.query.repository.QueryForestEmotionMapper;
 import java.util.List;
@@ -13,7 +14,16 @@ public class QueryForestEmotionServiceImpl implements QueryForestEmotionService 
     private QueryForestEmotionMapper queryForestEmotionMapper;
 
     // 사용자가 보유한 기억의 조각 카테고리별 조회
-    public List<QueryForestEmotionUserItemDTO> getPieceOfMemory(int userId, int categoryId) {
+    public List<QueryForestEmotionUserItemDTO> getPieceOfMemory (int userId, int categoryId) {
         return queryForestEmotionMapper.findPieceOfMemory(userId, categoryId);
     }
+
+    public List<QueryForestEmotionMailboxDTO> getMailboxList (int userId, int forestId) {
+        return queryForestEmotionMapper.findMailboxList(userId, forestId);
+    }
+
+    public List<QueryForestEmotionMailboxDTO> getMailboxDetail (int userId, int id) {
+        return queryForestEmotionMapper.findMailboxDetail(userId, id);
+    }
+
 }

--- a/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
+++ b/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
@@ -14,14 +14,15 @@
         <result property="imageUrl" column="image_url"/>
     </resultMap>
     <resultMap id="QueryForestMailboxListResultMap"
-               type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO">
+               type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO">
         <result property="id" column="id"/>
         <result property="createdAt" column="created_at"/>
+        <result property="forestId" column="forest_id"/>
     </resultMap>
     <resultMap id="QueryForestMailboxDetailResultMap"
                type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO">
         <result property="id" column="id"/>
-        <result property="contents" column="contents"/>
+        <result property="content" column="content"/>
         <result property="createdAt" column="created_at"/>
         <result property="forestId" column="forest_id"/>
         <result property="userId" column="user_id"/>
@@ -46,23 +47,26 @@
         SELECT
                m.id
              , m.created_at
+             , m.forest_id
           FROM mailbox m
+          JOIN forest f ON m.forest_id = f.id
          WHERE m.forest_id = #{forestId}
            AND m.is_deleted = false
+           AND f.is_public = true
          ORDER BY m.created_at DESC;
     </select>
 
     <select id="findMailboxDetail" resultMap="QueryForestMailboxDetailResultMap">
         SELECT
-            m.id
-             , m.contents
+               m.id
+             , m.content
              , m.created_at
              , m.forest_id
              , m.user_id
-        FROM mailbox m
-        WHERE m.user_id = #{userId}
-          AND m.id = #{id}
-          AND m.is_deleted = false;
+          FROM mailbox m
+          JOIN forest f ON m.forest_id = f.id
+         WHERE m.id = #{id}
+           AND m.is_deleted = false
+           AND f.is_public = true;
     </select>
-
 </mapper>

--- a/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
+++ b/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
@@ -13,6 +13,19 @@
         <result property="categoryId" column="category_id"/>
         <result property="imageUrl" column="image_url"/>
     </resultMap>
+    <resultMap id="QueryForestMailboxListResultMap"
+               type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO">
+        <result property="id" column="id"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+    <resultMap id="QueryForestMailboxDetailResultMap"
+               type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO">
+        <result property="id" column="id"/>
+        <result property="contents" column="contents"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="forestId" column="forest_id"/>
+        <result property="userId" column="user_id"/>
+    </resultMap>
 
     <select id="findPieceOfMemory" resultMap="QueryForestUserItemResultMap">
         SELECT
@@ -24,9 +37,32 @@
              , i.category_id
              , i.image_url
           FROM user_item ui
-          JOIN item i ON ui.id = i.id
-         WHERE i.category_id = #{categoryId}
-           AND ui.id = #{userId}
-         ORDER BY ui.id DESC;
+          JOIN item i ON ui.item_id = i.id
+         WHERE ui.user_id = #{userId}
+           AND i.category_id = #{categoryId}
     </select>
+
+    <select id="findMailboxList" resultMap="QueryForestMailboxListResultMap">
+        SELECT
+               m.id
+             , m.created_at
+          FROM mailbox m
+         WHERE m.forest_id = #{forestId}
+           AND m.is_deleted = false
+         ORDER BY m.created_at DESC;
+    </select>
+
+    <select id="findMailboxDetail" resultMap="QueryForestMailboxDetailResultMap">
+        SELECT
+            m.id
+             , m.contents
+             , m.created_at
+             , m.forest_id
+             , m.user_id
+        FROM mailbox m
+        WHERE m.user_id = #{userId}
+          AND m.id = #{id}
+          AND m.is_deleted = false;
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 
#21 
- close #21 
## ✅ 작업 사항
<br>
방명록 리스트 조회 및 상세 조회 기능 개발 완료
is_public = true인 감정의 숲의 방명록은 누구나 들어와서 확인 가능하다.
UI상 익명으로 뿌려지는 것은 프론트에서 처리
## 📸 스크린샷 (선택)
<br>
<img width="955" alt="image" src="https://github.com/user-attachments/assets/2c324d5e-29b2-45ad-abfc-074eb0beddb4" />
<img width="955" alt="image" src="https://github.com/user-attachments/assets/55d66948-0ba7-4367-b5ee-d8acb6f4679c" />

## 👩‍💻 공유 포인트 및 논의 사항
