### PR TITLE
🌟 feat: 숲 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
@@ -2,6 +2,7 @@ package com.x1.groo.forest.emotion.query.controller;
 
 import com.x1.groo.common.JwtUtil;
 import com.x1.groo.forest.emotion.command.application.service.CommandEmotionForestService;
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
@@ -60,11 +61,17 @@ public class QueryForestEmotionController {
         return queryForestEmotionService.getMailboxList(forestId);
     }
 
-
+    // 감정의 숲에 작성된 방명록 상세 조회
     @GetMapping("/mailbox-detail/{id}")
     public List<QueryForestEmotionMailboxDTO> getMailboxDetail(@PathVariable int id) {
 
         return queryForestEmotionService.getMailboxDetail(id);
     }
 
+    // 감정의 숲 상세 조회
+    @GetMapping("/detail/{forestId}")
+    public List<QueryForestEmotionDetailDTO> getForestDetail(@PathVariable int forestId) {
+
+        return queryForestEmotionService.getForestDetail(forestId);
+    }
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/dto/PlacementDTO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/dto/PlacementDTO.java
@@ -1,0 +1,24 @@
+package com.x1.groo.forest.emotion.query.dto;
+
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PlacementDTO {
+
+    private int itemId;
+    private String itemName;
+    private String itemImageUrl;
+
+    private int userItemId;
+    private int userItemPlacedCount;
+
+    private int placementId;
+    private BigDecimal placementPositionX;
+    private BigDecimal placementPositionY;
+
+}

--- a/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDetailDTO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDetailDTO.java
@@ -1,6 +1,7 @@
 package com.x1.groo.forest.emotion.query.dto;
 
-import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -18,15 +19,6 @@ public class QueryForestEmotionDetailDTO {
 
     private String backgroundImageUrl;
 
-    private int placementId;
-    private BigDecimal placementPositionX;
-    private BigDecimal placementPositionY;
-
-    private int userItemId;
-    private int userItemPlacedCount;
-
-    private int itemId;
-    private String itemName;
-    private String itemImageUrl;
+    private List<PlacementDTO> placementList = new ArrayList<>();
 
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDetailDTO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDetailDTO.java
@@ -1,5 +1,6 @@
 package com.x1.groo.forest.emotion.query.dto;
 
+import java.math.BigDecimal;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -18,8 +19,8 @@ public class QueryForestEmotionDetailDTO {
     private String backgroundImageUrl;
 
     private int placementId;
-    private double placementPositionX;
-    private double placementPositionY;
+    private BigDecimal placementPositionX;
+    private BigDecimal placementPositionY;
 
     private int userItemId;
     private int userItemPlacedCount;

--- a/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDetailDTO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDetailDTO.java
@@ -1,0 +1,31 @@
+package com.x1.groo.forest.emotion.query.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class QueryForestEmotionDetailDTO {
+
+    private int forestId;
+    private String name;
+    private Boolean isPublic;
+    private int backgroundId;
+    private int userId;
+
+    private String backgroundImageUrl;
+
+    private int placementId;
+    private double placementPositionX;
+    private double placementPositionY;
+
+    private int userItemId;
+    private int userItemPlacedCount;
+
+    private int itemId;
+    private String itemName;
+    private String itemImageUrl;
+
+}

--- a/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
@@ -1,5 +1,6 @@
 package com.x1.groo.forest.emotion.query.repository;
 
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
@@ -22,5 +23,9 @@ public interface QueryForestEmotionMapper {
 
     List<QueryForestEmotionMailboxDTO> findMailboxDetail(
             @Param("id") int id
+    );
+
+    List<QueryForestEmotionDetailDTO> findForestDetail(
+            @Param("forestId") int forestId
     );
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
@@ -1,5 +1,6 @@
 package com.x1.groo.forest.emotion.query.service;
 
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
@@ -11,5 +12,7 @@ public interface QueryForestEmotionService {
     List<QueryForestEmotionMailboxListDTO> getMailboxList(int forestId);
 
     List<QueryForestEmotionMailboxDTO> getMailboxDetail(int id);
+
+    List<QueryForestEmotionDetailDTO> getForestDetail(int forestId);
 }
 

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.x1.groo.forest.emotion.query.service;
 
+import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
@@ -25,6 +26,10 @@ public class QueryForestEmotionServiceImpl implements QueryForestEmotionService 
 
     public List<QueryForestEmotionMailboxDTO> getMailboxDetail (int id) {
         return queryForestEmotionMapper.findMailboxDetail(id);
+    }
+
+    public List<QueryForestEmotionDetailDTO> getForestDetail(int forestId) {
+        return queryForestEmotionMapper.findForestDetail(forestId);
     }
 
 }

--- a/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
+++ b/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
@@ -13,12 +13,14 @@
         <result property="categoryId" column="category_id"/>
         <result property="imageUrl" column="image_url"/>
     </resultMap>
+
     <resultMap id="QueryForestMailboxListResultMap"
                type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO">
         <result property="id" column="id"/>
         <result property="createdAt" column="created_at"/>
         <result property="forestId" column="forest_id"/>
     </resultMap>
+
     <resultMap id="QueryForestMailboxDetailResultMap"
                type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO">
         <result property="id" column="id"/>
@@ -27,22 +29,25 @@
         <result property="forestId" column="forest_id"/>
         <result property="userId" column="user_id"/>
     </resultMap>
+
     <resultMap id="QueryForestDetailResultMap" type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO">
         <result property="forestId" column="forest_id"/>
         <result property="name" column="forest_name"/>
         <result property="isPublic" column="is_public"/>
         <result property="backgroundId" column="background_id"/>
         <result property="userId" column="user_id"/>
-
         <result property="backgroundImageUrl" column="background_image_url"/>
+        <collection property="placementList"
+                    resultMap="com.x1.groo.forest.emotion.query.repository.QueryForestEmotionMapper.PlacementDTOMap"/>
 
+    </resultMap>
+
+    <resultMap id="PlacementDTOMap" type="com.x1.groo.forest.emotion.query.dto.PlacementDTO">
         <result property="placementId" column="placement_id"/>
-        <result property="placementPositionX" column="position_x"/>
-        <result property="placementPositionY" column="position_y"/>
-
+        <result property="placementPositionX" column="placement_position_x"/>
+        <result property="placementPositionY" column="placement_position_y"/>
         <result property="userItemId" column="user_item_id"/>
         <result property="userItemPlacedCount" column="placed_count"/>
-
         <result property="itemId" column="item_id"/>
         <result property="itemName" column="item_name"/>
         <result property="itemImageUrl" column="item_image_url"/>
@@ -98,20 +103,23 @@
              , f.background_id AS background_id
              , f.user_id
              , b.image_url AS background_image_url
+
+             , p.id AS placement_id
+             , p.position_x AS placement_position_x
+             , p.position_y AS placement_position_y
+             , ui.id AS user_item_id
+             , ui.placed_count
+
              , i.id AS item_id
              , i.name AS item_name
              , i.image_url AS item_image_url
-             , ui.id AS user_item_id
-             , ui.placed_count
-             , p.id AS placement_id
-             , p.position_x
-             , p.position_y
-          FROM forest f
-          JOIN background b ON f.background_id = b.id
-          JOIN placement p ON f.id = p.forest_id
-          JOIN user_item ui ON p.user_item_id = ui.id
-          JOIN item i ON ui.item_id = i.id
-         WHERE f.id = #{forestId}
-           AND f.is_public = true;
+        FROM forest f
+                 LEFT JOIN background b ON f.background_id = b.id
+                 LEFT JOIN placement p ON p.forest_id = f.id
+                 LEFT JOIN user_item ui ON p.user_item_id = ui.id
+                 LEFT JOIN item i ON ui.item_id = i.id
+        WHERE f.id = #{forestId}
+           AND f.is_public = true
+           AND p.id IS NOT NULL;
     </select>
 </mapper>

--- a/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
+++ b/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
@@ -27,6 +27,26 @@
         <result property="forestId" column="forest_id"/>
         <result property="userId" column="user_id"/>
     </resultMap>
+    <resultMap id="QueryForestDetailResultMap" type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO">
+        <result property="forestId" column="forest_id"/>
+        <result property="name" column="forest_name"/>
+        <result property="isPublic" column="is_public"/>
+        <result property="backgroundId" column="background_id"/>
+        <result property="userId" column="user_id"/>
+
+        <result property="backgroundImageUrl" column="background_image_url"/>
+
+        <result property="placementId" column="placement_id"/>
+        <result property="placementPositionX" column="position_x"/>
+        <result property="placementPositionY" column="position_y"/>
+
+        <result property="userItemId" column="user_item_id"/>
+        <result property="userItemPlacedCount" column="placed_count"/>
+
+        <result property="itemId" column="item_id"/>
+        <result property="itemName" column="item_name"/>
+        <result property="itemImageUrl" column="item_image_url"/>
+    </resultMap>
 
     <select id="findPieceOfMemory" resultMap="QueryForestUserItemResultMap">
         SELECT
@@ -67,6 +87,31 @@
           JOIN forest f ON m.forest_id = f.id
          WHERE m.id = #{id}
            AND m.is_deleted = false
+           AND f.is_public = true;
+    </select>
+
+    <select id="findForestDetail" resultMap="QueryForestDetailResultMap">
+        SELECT
+               f.id AS forest_id
+             , f.name AS forest_name
+             , f.is_public
+             , f.background_id AS background_id
+             , f.user_id
+             , b.image_url AS background_image_url
+             , i.id AS item_id
+             , i.name AS item_name
+             , i.image_url AS item_image_url
+             , ui.id AS user_item_id
+             , ui.placed_count
+             , p.id AS placement_id
+             , p.position_x
+             , p.position_y
+          FROM forest f
+          JOIN background b ON f.background_id = b.id
+          JOIN placement p ON f.id = p.forest_id
+          JOIN user_item ui ON p.user_item_id = ui.id
+          JOIN item i ON ui.item_id = i.id
+         WHERE f.id = #{forestId}
            AND f.is_public = true;
     </select>
 </mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #37 
- close #40 

## ✅ 작업 사항
<br>
숲 상세보기 기능 조회
## 📸 스크린샷 (선택)
<br>
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/458de7a6-46cc-4973-850f-a88197d5dc83" />
다섯 개의 테이블이 엮여 있어 제가 판단한 대로 조회할 컬럼들을 설정했습니다.
14개의 값들이 정상적으로 나오는 것 확인 완료 했습니다.
혹시 조회 컬럼에 있어서 수정사항이 필요하면 수정하도록 하겠습니다!
<br>
<br>
<img width="958" alt="image" src="https://github.com/user-attachments/assets/ed602269-1bfd-4067-84bb-f61cd68ab0d3" />
1. 이런식으로 하나의 숲에 대한 정보에서 list형식으로 아이템 배치 이뤄지도록 수정 완료; collection 태그 사용
2. 쿼리 조건절에 placeId가 존재하는 것만 조회되도록 쿼리 수정
## 👩‍💻 공유 포인트 및 논의 사항
