### PR TITLE
🌟 feat: 우정의 숲 탈퇴 및 삭제기능 구현

### DIFF
--- a/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/controller/CommandMateController.java
@@ -4,12 +4,15 @@ import com.x1.groo.common.JwtUtil;
 import com.x1.groo.forest.mate.command.application.service.CommandMateService;
 import com.x1.groo.forest.mate.command.domain.vo.CreateInviteRequest;
 import io.jsonwebtoken.Claims;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/mate")
+@Slf4j
 public class CommandMateController {
 
     private final JwtUtil jwtUtil;
@@ -19,6 +22,19 @@ public class CommandMateController {
     public CommandMateController(JwtUtil jwtUtil, CommandMateService commandMateService) {
         this.jwtUtil = jwtUtil;
         this.commandMateService = commandMateService;
+    }
+
+    @Transactional
+    // 공유의 숲 탈퇴 및 숲 삭제(0명이 되었을 때)
+    @DeleteMapping("/quit")
+    public ResponseEntity<String> quit(@RequestHeader(value = "Authorization") String authorizationHeader,
+                                        @RequestParam int forestId) {
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        commandMateService.quit(userId,forestId);
+        return ResponseEntity.ok("공유의 숲 탈퇴 되었습니다.");
     }
 
     // 초대 링크 생성
@@ -38,7 +54,7 @@ public class CommandMateController {
     public ResponseEntity<String> acceptInvite (@RequestHeader(value = "Authorization") String authorizationHeader,
                                                 @PathVariable String inviteCode) {
         // "Bearer " 부분 제거
-        String token = authorizationHeader.replace("Bearer", "").trim();
+        String token = authorizationHeader.replace("Bearer ", "").trim();
         Claims claims = jwtUtil.parseJwt(token);
         int userId = ((Number) claims.get("userId")).intValue();
 

--- a/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/application/service/CommandMateService.java
@@ -4,4 +4,6 @@ public interface CommandMateService {
     String createInviteLink(int forestId);
 
     void acceptInvite(int userId, String inviteCode);
+
+    void quit(int userId, int forestId);
 }

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/repository/SharedForestRepository.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/repository/SharedForestRepository.java
@@ -7,4 +7,6 @@ public interface SharedForestRepository extends JpaRepository<SharedForestEntity
     boolean existsByUserIdAndForestId(int userId, int forestId);
 
     int countByForestId(int forestId);
+
+    void deleteByUserIdAndForestId(int userId, int id);
 }

--- a/src/main/java/com/x1/groo/forest/mate/command/domain/vo/QuitForestCommand.java
+++ b/src/main/java/com/x1/groo/forest/mate/command/domain/vo/QuitForestCommand.java
@@ -1,0 +1,15 @@
+package com.x1.groo.forest.mate.command.domain.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuitForestCommand {
+    private int forestId;
+
+}
+

--- a/src/main/java/com/x1/groo/security/config/SecurityConfig.java
+++ b/src/main/java/com/x1/groo/security/config/SecurityConfig.java
@@ -71,11 +71,11 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**",
-                                "/v3/api-docs/**", "/health")
+                                "/v3/api-docs/**", "/health" )
                         .permitAll()
                         .requestMatchers("/auth/**", "/mails/**", "/image/**")
                         .permitAll()
-                        .requestMatchers("/items/**")
+                        .requestMatchers("/items/**", "/mate/** ")
                         .authenticated()
                         .anyRequest()
                         .authenticated()

--- a/src/main/java/com/x1/groo/security/config/SecurityConfig.java
+++ b/src/main/java/com/x1/groo/security/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/auth/**", "/mails/**", "/image/**")
                         .permitAll()
-                        .requestMatchers("/items/**", "/mate/** ")
+                        .requestMatchers("/items/**")
                         .authenticated()
                         .anyRequest()
                         .authenticated()


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #41 

## ✅ 작업 사항
우정의 숲 탈퇴하면 db에 반영되도록 했고 우정의 숲의 정원이 0명일때 숲 삭제하도록 했습니다.

<br>

## 📸 스크린샷 
> 탈퇴가 완료 되었을 때 "공유의 숲 탈퇴 되었습니다." 문구 출력
<img width="1081" alt="스크린샷 2025-04-29 13 28 02" src="https://github.com/user-attachments/assets/6f9f2f8e-7442-42c4-98d6-a68a4acbf0b7" />
<br>

## 👩‍💻 공유 포인트 및 논의 사항
