### PR TITLE
🌟 feat: 숲 공개여부 전환 기능 구현

### DIFF
--- a/src/main/java/com/x1/groo/forest/emotion/command/application/controller/CommandEmotionForestController.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/application/controller/CommandEmotionForestController.java
@@ -4,7 +4,7 @@ import com.x1.groo.common.JwtUtil;
 import com.x1.groo.forest.emotion.command.application.service.CommandEmotionForestService;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestMailboxVO;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestPlacementVO;
-import com.x1.groo.forest.emotion.command.domain.vo.UpdatePublicRequest;
+import com.x1.groo.forest.emotion.command.domain.vo.RequestPublicVO;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestReplacementVO;
 import io.jsonwebtoken.Claims;
 import lombok.extern.slf4j.Slf4j;
@@ -114,17 +114,18 @@ public class CommandEmotionForestController {
 
     // 숲 공개여부
     @PatchMapping("/public/{forestId}")
-    public ResponseEntity<Void> updateForestPublic(@RequestHeader(value = "Authorization") String authorizationHeader,
-                                   @PathVariable int forestId,
-                                   @RequestBody UpdatePublicRequest request) {
-
+    public ResponseEntity<Void> updateForestPublic(@PathVariable int forestId,
+                                                   @RequestHeader(value = "Authorization") String authorizationHeader) {
+        // "Bearer " 부분 제거
         String token = authorizationHeader.replace("Bearer", "").trim();
-        Claims claims = jwtUtil.parseJwt(token);
-        int userId = ((Number) claims.get("userId")).intValue();
+        Claims claims = jwtUtil.parseJwt(token);  // JWT 토큰 파싱
+        int userId = ((Number) claims.get("userId")).intValue();  // userId 추출
 
-        commandEmotionForestService.updateForestPublic(forestId, userId, request.isPublic());
+        // 숲 공개여부 변경 로직 실행
+        commandEmotionForestService.updateForestPublic(forestId, userId);
 
         return ResponseEntity.ok().build();
     }
+
 
 }

--- a/src/main/java/com/x1/groo/forest/emotion/command/application/controller/CommandEmotionForestController.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/application/controller/CommandEmotionForestController.java
@@ -4,6 +4,7 @@ import com.x1.groo.common.JwtUtil;
 import com.x1.groo.forest.emotion.command.application.service.CommandEmotionForestService;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestMailboxVO;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestPlacementVO;
+import com.x1.groo.forest.emotion.command.domain.vo.UpdatePublicRequest;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestReplacementVO;
 import io.jsonwebtoken.Claims;
 import lombok.extern.slf4j.Slf4j;
@@ -107,6 +108,21 @@ public class CommandEmotionForestController {
         int userId = ((Number) claims.get("userId")).intValue();
 
         commandEmotionForestService.deleteMailbox(userId, mailboxId, forestId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    // 숲 공개여부
+    @PatchMapping("/public/{forestId}")
+    public ResponseEntity<Void> updateForestPublic(@RequestHeader(value = "Authorization") String authorizationHeader,
+                                   @PathVariable int forestId,
+                                   @RequestBody UpdatePublicRequest request) {
+
+        String token = authorizationHeader.replace("Bearer", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        commandEmotionForestService.updateForestPublic(forestId, userId, request.isPublic());
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestService.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestService.java
@@ -17,5 +17,5 @@ public interface CommandEmotionForestService {
 
     void deleteMailbox(int userId, int mailboxId, int forestId);
 
-    void updateForestPublic(int forestId, int userId, boolean Public);
+    void updateForestPublic(int forestId, int userId);
 }

--- a/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestService.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestService.java
@@ -16,4 +16,6 @@ public interface CommandEmotionForestService {
     void createMailbox(int userId, RequestMailboxVO requestMailboxVO);
 
     void deleteMailbox(int userId, int mailboxId, int forestId);
+
+    void updateForestPublic(int forestId, int userId, boolean Public);
 }

--- a/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestServiceImpl.java
@@ -7,9 +7,10 @@ import com.x1.groo.forest.emotion.command.domain.vo.RequestPlacementVO;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestReplacementVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -148,5 +149,20 @@ public class CommandEmotionForestServiceImpl implements CommandEmotionForestServ
         }
 
         mailboxRepository.softDeleteById(mailboxId);
+    }
+
+    @Override
+    public void updateForestPublic(int forestId, int userId, boolean isPublic) {
+        ForestEntity forest = forestRepository.findById(forestId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 숲입니다."));
+
+        // 여기서 꼭 본인 확인
+        if (forest.getUser().getId() != userId) {
+            throw new AccessDeniedException("본인 소유의 숲만 수정할 수 있습니다.");
+        }
+
+        // 본인 소유면 공개 여부 수정
+        forest.setPublic(isPublic);
+        forestRepository.save(forest);
     }
 }

--- a/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestServiceImpl.java
@@ -152,7 +152,7 @@ public class CommandEmotionForestServiceImpl implements CommandEmotionForestServ
     }
 
     @Override
-    public void updateForestPublic(int forestId, int userId, boolean isPublic) {
+    public void updateForestPublic(int forestId, int userId) {
         ForestEntity forest = forestRepository.findById(forestId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 숲입니다."));
 
@@ -161,8 +161,11 @@ public class CommandEmotionForestServiceImpl implements CommandEmotionForestServ
             throw new AccessDeniedException("본인 소유의 숲만 수정할 수 있습니다.");
         }
 
-        // 본인 소유면 공개 여부 수정
-        forest.setPublic(isPublic);
+        // 숲의 공개 여부 토글 (true -> false, false -> true)
+        boolean currentPublicStatus = forest.isPublic();
+        forest.setPublic(!currentPublicStatus);
+
+        // 숲 정보 저장
         forestRepository.save(forest);
     }
 }

--- a/src/main/java/com/x1/groo/forest/emotion/command/domain/vo/RequestPublicVO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/domain/vo/RequestPublicVO.java
@@ -3,12 +3,10 @@ package com.x1.groo.forest.emotion.command.domain.vo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Setter
-public class UpdatePublicRequest {
+public class RequestPublicVO {
     private boolean isPublic;
 }

--- a/src/main/java/com/x1/groo/forest/emotion/command/domain/vo/UpdatePublicRequest.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/domain/vo/UpdatePublicRequest.java
@@ -1,0 +1,14 @@
+package com.x1.groo.forest.emotion.command.domain.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class UpdatePublicRequest {
+    private boolean isPublic;
+}


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #

## ✅ 작업 사항
<br>
joanne이 작업하던 코드 이어받아 같은 브랜치에서 작업 완료함.
불필요한 body입력 대신 하나의 요청으로 공개 상태 변경 가능하게 구현 완료

## 📸 스크린샷 (선택)
<br>
<img width="519" alt="image" src="https://github.com/user-attachments/assets/3ece8769-96c6-4d55-af9c-ba44cdcd1535" />
<img width="772" alt="image" src="https://github.com/user-attachments/assets/f752aed8-5550-4cab-a4c0-e2cc446101d9" />
<br>
<img width="514" alt="image" src="https://github.com/user-attachments/assets/f3d018d8-c96d-499f-b739-31407b96c068" />
<img width="627" alt="image" src="https://github.com/user-attachments/assets/b97b9c4f-34d7-40be-a66b-298d9070f401" />
<br>
is_public이 true일 때 조회하면 보이지만 false일 때 조회하면 조회 불가능.
## 👩‍💻 공유 포인트 및 논의 사항
