### PR TITLE
🌟 feat: 일기 등록시 감정 및 카테고리별 감정 아이템 추출 완료

### DIFF
--- a/src/main/java/com/x1/groo/diary/dto/DiaryRequestDTO.java
+++ b/src/main/java/com/x1/groo/diary/dto/DiaryRequestDTO.java
@@ -9,4 +9,5 @@ import lombok.Data;
 public class DiaryRequestDTO {
     private int forestId;
     private String content;
+    private int categoryId;
 }

--- a/src/main/java/com/x1/groo/diary/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/x1/groo/diary/dto/DiaryResponseDTO.java
@@ -1,9 +1,11 @@
 package com.x1.groo.diary.dto;
 
+import com.x1.groo.item.dto.CategoryEmotionItemDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -17,4 +19,6 @@ public class DiaryResponseDTO {
     private String mainEmotion;
     private String weather;
     private String content;
+
+    private List<CategoryEmotionItemDTO> emotionItems;
 }

--- a/src/main/java/com/x1/groo/diary/service/DiaryServiceImpl.java
+++ b/src/main/java/com/x1/groo/diary/service/DiaryServiceImpl.java
@@ -13,6 +13,8 @@ import com.x1.groo.diary.repository.DiaryEmotionRepository;
 import com.x1.groo.diary.repository.DiaryRepository;
 import com.x1.groo.forest.emotion.command.domain.repository.ForestRepository;
 import com.x1.groo.forest.emotion.command.domain.repository.EmotionSharedForestRepository;
+import com.x1.groo.item.dto.CategoryEmotionItemDTO;
+import com.x1.groo.item.service.ItemService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -32,11 +35,13 @@ public class DiaryServiceImpl implements DiaryService {
     private final EmotionService emotionService;
     private final ForestRepository forestRepo;
     private final EmotionSharedForestRepository sharedForestRepo;
+    private final ItemService itemService;
 
     @Override
     @Transactional
     public DiaryResponseDTO createDiary(DiaryRequestDTO req, int userId) {
         int forestId = req.getForestId();
+        int categoryId = req.getCategoryId();
         // 권한 체크
         boolean owner = forestRepo.findById(forestId)
                 .map(f -> f.getUser().getId() == userId)
@@ -88,6 +93,8 @@ public class DiaryServiceImpl implements DiaryService {
             emotionRepo.save(de);
         });
 
+        List<CategoryEmotionItemDTO> emotionItems = itemService.findItemsByCategoryAndEmotion(categoryId, mainEmotion);
+
         // DTO 반환
         return new DiaryResponseDTO(
                 savedDiary.getId(),
@@ -96,7 +103,8 @@ public class DiaryServiceImpl implements DiaryService {
                 top2,
                 mainEmotion,
                 weather,          // aiRes.getWeather() 값
-                req.getContent()
+                req.getContent(),
+                emotionItems
         );
     }
 

--- a/src/main/java/com/x1/groo/item/controller/UserItemStorageController.java
+++ b/src/main/java/com/x1/groo/item/controller/UserItemStorageController.java
@@ -1,0 +1,41 @@
+package com.x1.groo.item.controller;
+
+import com.x1.groo.common.JwtUtil;
+import com.x1.groo.item.service.UserItemStorageService;
+import io.jsonwebtoken.Claims;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping
+@Slf4j
+public class UserItemStorageController {
+
+    private final UserItemStorageService userItemStorageService;
+    private final JwtUtil jwtUtil;
+
+    @Autowired
+    public UserItemStorageController(UserItemStorageService userItemStorageService, JwtUtil jwtUtil) {
+        this.userItemStorageService = userItemStorageService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    // 아이템 획득 시 나의 보관소에 아이템이 추가됨
+    @PostMapping("/item-storage")
+    public ResponseEntity<Void> saveItemToStorage(@RequestHeader(value = "Authorization") String authorizationHeader,
+                                                  @RequestParam int itemId, @RequestParam int forestId) {
+
+        // "Bearer " 부분 제거
+        String token = authorizationHeader.replace("Bearer", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        log.info("userId = {}", userId);
+
+        userItemStorageService.saveItemToStorage(userId, itemId, forestId);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/x1/groo/item/domain/storage/aggregate/UserItemStorageEntity.java
+++ b/src/main/java/com/x1/groo/item/domain/storage/aggregate/UserItemStorageEntity.java
@@ -1,0 +1,4 @@
+package com.x1.groo.item.domain.storage.aggregate;
+
+public class UserItemStorageEntity {
+}

--- a/src/main/java/com/x1/groo/item/domain/storage/aggregate/UserItemStorageEntity.java
+++ b/src/main/java/com/x1/groo/item/domain/storage/aggregate/UserItemStorageEntity.java
@@ -1,4 +1,35 @@
 package com.x1.groo.item.domain.storage.aggregate;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@ToString
+@Table(name="user_item")
 public class UserItemStorageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name="item_id")
+    private int itemId;
+
+    @Column(name="user_id")
+    private int userId;
+
+    @Column(name="total_count")
+    private int totalCount;
+
+    @Column(name="placed_count")
+    private int placedCount;
+
+    @Column(name= "forest_id")
+    private int forestId;
 }

--- a/src/main/java/com/x1/groo/item/domain/storage/repository/UserItemStorageRepository.java
+++ b/src/main/java/com/x1/groo/item/domain/storage/repository/UserItemStorageRepository.java
@@ -1,4 +1,13 @@
 package com.x1.groo.item.domain.storage.repository;
 
-public interface UserItemStorageRepository {
+import com.x1.groo.item.domain.storage.aggregate.UserItemStorageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserItemStorageRepository extends JpaRepository<UserItemStorageEntity, Integer> {
+
+    Optional<UserItemStorageEntity> findByUserIdAndItemIdAndForestId(int userId, int itemId, int forestId);
 }

--- a/src/main/java/com/x1/groo/item/domain/storage/repository/UserItemStorageRepository.java
+++ b/src/main/java/com/x1/groo/item/domain/storage/repository/UserItemStorageRepository.java
@@ -1,0 +1,4 @@
+package com.x1.groo.item.domain.storage.repository;
+
+public interface UserItemStorageRepository {
+}

--- a/src/main/java/com/x1/groo/item/service/UserItemStorageService.java
+++ b/src/main/java/com/x1/groo/item/service/UserItemStorageService.java
@@ -1,0 +1,6 @@
+package com.x1.groo.item.service;
+
+public interface UserItemStorageService {
+
+    void saveItemToStorage(int userId, int itemId, int forestId);
+}

--- a/src/main/java/com/x1/groo/item/service/UserItemStorageServiceImpl.java
+++ b/src/main/java/com/x1/groo/item/service/UserItemStorageServiceImpl.java
@@ -1,0 +1,65 @@
+package com.x1.groo.item.service;
+
+import com.x1.groo.forest.emotion.command.domain.aggregate.ForestEntity;
+import com.x1.groo.forest.emotion.command.domain.repository.ForestRepository;
+import com.x1.groo.forest.emotion.command.domain.repository.EmotionSharedForestRepository;
+import com.x1.groo.item.domain.storage.aggregate.UserItemStorageEntity;
+import com.x1.groo.item.domain.storage.repository.UserItemStorageRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserItemStorageServiceImpl implements UserItemStorageService {
+
+    private UserItemStorageRepository userItemStorageRepo;
+    private ForestRepository forestRepo;
+    private EmotionSharedForestRepository sharedForestRepo;
+
+    @Autowired
+    public UserItemStorageServiceImpl(UserItemStorageRepository userItemStorageRepository,
+                                      ForestRepository forestRepository,
+                                      EmotionSharedForestRepository sharedForestRepository) {
+        this.userItemStorageRepo = userItemStorageRepository;
+        this.forestRepo = forestRepository;
+        this.sharedForestRepo = sharedForestRepository;
+
+    }
+
+    @Override
+    public void saveItemToStorage(int userId, int itemId, int forestId) {
+
+        //  1. 권한 체크 (개인숲 소유자 or 공유숲 사용자)
+        boolean isOwner = forestRepo.findById(forestId)
+                .map(forest -> forest.getUser().getId() == userId)
+                .orElse(false);
+
+        boolean hasSharedAccess = sharedForestRepo.existsByUserIdAndForestId(userId, forestId);
+
+        if (!(isOwner || hasSharedAccess)) {
+            throw new AccessDeniedException("이 숲에 대한 접근 권한이 없습니다.");
+        }
+
+        // 2. 해당 유저의 보관함에 아이템이 있는지 확인
+        UserItemStorageEntity existing = userItemStorageRepo
+                .findByUserIdAndItemIdAndForestId(userId, itemId, forestId)
+                .orElse(null);
+
+        if (existing != null) {
+            // 보유 중이면 count + 1
+            existing.setTotalCount(existing.getTotalCount() + 1);
+            userItemStorageRepo.save(existing);
+        } else {
+            // 보유하지 않은 경우 새로 저장
+            UserItemStorageEntity newItem = UserItemStorageEntity.builder()
+                    .userId(userId)
+                    .itemId(itemId)
+                    .forestId(forestId)
+                    .totalCount(1)
+                    .placedCount(0)
+                    .build();
+            userItemStorageRepo.save(newItem);
+        }
+    }
+
+}

--- a/src/main/resources/com/x1/groo/item/repository/ItemMapper.xml
+++ b/src/main/resources/com/x1/groo/item/repository/ItemMapper.xml
@@ -28,14 +28,13 @@
     <select id="selectItemsByCategoryAndEmotion" resultMap="categoryEmotionItemMap">
         SELECT
             ID
-          , NAME
-          , IMAGE_URL
-          , EMOTION
+             , NAME
+             , IMAGE_URL
+             , EMOTION
         FROM ITEM
-        WHERE
-            CATEGORY_ID = #{categoryId}
-            AND EMOTION = #{mainEmotion}
+        WHERE CATEGORY_ID = #{categoryId}
+          AND EMOTION = #{mainEmotion}
         ORDER BY RAND()
-        LIMIT 3
+            LIMIT 3
     </select>
 </mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #13 

## ✅ 작업 사항
<br>
diary 도메인의 ResponseDTO, service 로직 수정하여 일기 등록 후 메인 감정에 해당하는 아이템 3개까지 추출되도록 로직 수정하였습니다. 

## 📸 스크린샷 (선택)
<br>
<img width="879" alt="image" src="https://github.com/user-attachments/assets/cd915991-6060-401d-997f-353befabc3c2" />

<img width="879" alt="image" src="https://github.com/user-attachments/assets/d42a7d9e-c720-431b-9034-52dea7da102b" />

## 👩‍💻 공유 포인트 및 논의 사항
