### PR TITLE
🚑  fix: 감정 일기 등록시 카테고리 값이 반환 안되는 오류 수정

### DIFF
--- a/src/main/resources/com/x1/groo/item/repository/ItemMapper.xml
+++ b/src/main/resources/com/x1/groo/item/repository/ItemMapper.xml
@@ -21,8 +21,8 @@
         <result property="id" column="id"/>
         <result property="name" column="name"/>
         <result property="imageUrl" column="image_url"/>
-        <result property="categoryId" column="category_id"/>
         <result property="emotion" column="emotion"/>
+        <result property="categoryId" column="category_id"/>
     </resultMap>
 
     <select id="selectItemsByCategoryAndEmotion" resultMap="categoryEmotionItemMap">
@@ -31,6 +31,7 @@
              , NAME
              , IMAGE_URL
              , EMOTION
+             , CATEGORY_ID
         FROM ITEM
         WHERE CATEGORY_ID = #{categoryId}
           AND EMOTION = #{mainEmotion}


### PR DESCRIPTION
## 🧩 이슈 번호 



## ✅ 작업 사항
<br>
일기 등록시 추출되는 감정 별 아이템에 카테고리 아이디 반환 값 추가하였습니다.

## 📸 스크린샷 (선택)
<br>
<img width="832" alt="image" src="https://github.com/user-attachments/assets/925f72cb-ccb5-459f-8577-04b43d032620" />


## 👩‍💻 공유 포인트 및 논의 사항
