### PR TITLE
🌟 feat: 감정의 숲 기록의 조각 조회에 forestId 추가

### DIFF
--- a/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
@@ -1,23 +1,19 @@
 package com.x1.groo.forest.emotion.query.controller;
 
 import com.x1.groo.common.JwtUtil;
-import com.x1.groo.forest.emotion.command.application.service.CommandEmotionForestService;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import com.x1.groo.forest.emotion.query.service.QueryForestEmotionService;
 import io.jsonwebtoken.Claims;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping
@@ -33,17 +29,20 @@ public class QueryForestEmotionController {
         this.queryForestEmotionService = queryForestEmotionService;
     }
 
-    @GetMapping("/items/{categoryId}")
+    // 기록의 조각 조회
+    @GetMapping("/items/{categoryId}/{forestId}")
     public ResponseEntity<?> getItems(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-            @PathVariable int categoryId) {
+            @PathVariable int categoryId,
+            @PathVariable int forestId) {
+
         String token = authorizationHeader.replace("Bearer", "").trim();
         Claims claims = jwtUtil.parseJwt(token);
         int userId = ((Number) claims.get("userId")).intValue();
 
         log.info("userId = {}", userId);
 
-        List<QueryForestEmotionUserItemDTO> items = queryForestEmotionService.getPieceOfMemory(userId, categoryId);
+        List<QueryForestEmotionUserItemDTO> items = queryForestEmotionService.getPieceOfMemory(userId, categoryId, forestId);
 
         if (items == null || items.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)

--- a/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
@@ -4,23 +4,27 @@ import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
-import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface QueryForestEmotionMapper {
 
+    int findUserIdByForestId(@Param("forestId") int forestId);
+
     // 사용자가 보유한 기억의 조각 카테고리별 조회
     List<QueryForestEmotionUserItemDTO> findPieceOfMemory(
             @Param("userId") int userId,
-            @Param("categoryId") int categoryId
-            );
+            @Param("categoryId") int categoryId,
+            @Param("forestId") int forestId
+    );
 
     List<QueryForestEmotionMailboxListDTO> findMailboxList(
             @Param("userId") int userId,
             @Param("forestId") int forestId
-            );
+    );
 
     List<QueryForestEmotionMailboxDTO> findMailboxDetail(
             @Param("userId") int userId,

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
@@ -4,10 +4,12 @@ import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
+import org.springframework.security.access.AccessDeniedException;
+
 import java.util.List;
 
 public interface QueryForestEmotionService {
-    List<QueryForestEmotionUserItemDTO> getPieceOfMemory(int userId, int categoryId);
+    List<QueryForestEmotionUserItemDTO> getPieceOfMemory(int userId, int categoryId, int forestId) throws AccessDeniedException;
 
     List<QueryForestEmotionMailboxListDTO> getMailboxList(int userId, int forestId);
 

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
@@ -5,9 +5,11 @@ import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
 import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
 import com.x1.groo.forest.emotion.query.repository.QueryForestEmotionMapper;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class QueryForestEmotionServiceImpl implements QueryForestEmotionService {
@@ -16,15 +18,21 @@ public class QueryForestEmotionServiceImpl implements QueryForestEmotionService 
     private QueryForestEmotionMapper queryForestEmotionMapper;
 
     // 사용자가 보유한 기억의 조각 카테고리별 조회
-    public List<QueryForestEmotionUserItemDTO> getPieceOfMemory (int userId, int categoryId) {
-        return queryForestEmotionMapper.findPieceOfMemory(userId, categoryId);
+    public List<QueryForestEmotionUserItemDTO> getPieceOfMemory(int userId, int categoryId, int forestId) {
+        int forestOwnerId = queryForestEmotionMapper.findUserIdByForestId(forestId);
+
+        if (forestOwnerId != userId) {
+            throw new AccessDeniedException("해당 유저는 forest에 접근할 수 없습니다.");
+        }
+
+        return queryForestEmotionMapper.findPieceOfMemory(userId, categoryId, forestId);
     }
 
-    public List<QueryForestEmotionMailboxListDTO> getMailboxList (int userId, int forestId) {
+    public List<QueryForestEmotionMailboxListDTO> getMailboxList(int userId, int forestId) {
         return queryForestEmotionMapper.findMailboxList(userId, forestId);
     }
 
-    public List<QueryForestEmotionMailboxDTO> getMailboxDetail (int userId, int id) {
+    public List<QueryForestEmotionMailboxDTO> getMailboxDetail(int userId, int id) {
         return queryForestEmotionMapper.findMailboxDetail(userId, id);
     }
 

--- a/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
+++ b/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
@@ -52,74 +52,77 @@
         <result property="itemImageUrl" column="item_image_url"/>
     </resultMap>
 
+    <select id="findUserIdByForestId" resultType="int">
+        SELECT user_id
+        FROM forest
+        WHERE id = #{forestId}
+    </select>
+
     <select id="findPieceOfMemory" resultMap="QueryForestUserItemResultMap">
-        SELECT
-               ui.id
+        SELECT ui.id
              , ui.item_id
              , ui.total_count
              , ui.placed_count
              , i.name
              , i.category_id
              , i.image_url
-          FROM user_item ui
-          JOIN item i ON ui.item_id = i.id
-         WHERE ui.user_id = #{userId}
-           AND i.category_id = #{categoryId}
+        FROM user_item ui
+                 JOIN item i ON ui.item_id = i.id
+        WHERE ui.user_id = #{userId}
+          AND i.category_id = #{categoryId}
+          AND ui.forest_id = #{forestId}
     </select>
 
     <select id="findMailboxList" resultMap="QueryForestMailboxListResultMap">
-        SELECT
-               m.id
+        SELECT m.id
              , m.created_at
              , m.forest_id
-          FROM mailbox m
-          JOIN forest f ON m.forest_id = f.id
-         WHERE m.forest_id = #{forestId}
-           AND m.is_deleted = false
-           AND (f.is_public = true
+        FROM mailbox m
+                 JOIN forest f ON m.forest_id = f.id
+        WHERE m.forest_id = #{forestId}
+          AND m.is_deleted = false
+          AND (f.is_public = true
             OR (f.is_public = false AND f.user_id = #{userId}))
-         ORDER BY m.created_at DESC;
+        ORDER BY m.created_at DESC;
     </select>
 
     <select id="findMailboxDetail" resultMap="QueryForestMailboxDetailResultMap">
-        SELECT
-               m.id
+        SELECT m.id
              , m.content
              , m.created_at
              , m.forest_id
              , m.user_id
-          FROM mailbox m
-          JOIN forest f ON m.forest_id = f.id
-         WHERE m.id = #{id}
-           AND m.is_deleted = false
-           AND (f.is_public = true
+        FROM mailbox m
+                 JOIN forest f ON m.forest_id = f.id
+        WHERE m.id = #{id}
+          AND m.is_deleted = false
+          AND (f.is_public = true
             OR (f.is_public = false AND f.user_id = #{userId}));
     </select>
 
 
     <select id="findForestDetail" resultMap="QueryForestDetailResultMap">
-        SELECT
-               f.id AS forest_id
-             , f.name AS forest_name
+        SELECT f.id            AS forest_id
+             , f.name          AS forest_name
              , f.is_public
              , f.background_id AS background_id
              , f.user_id
-             , b.image_url AS background_image_url
-             , p.id AS placement_id
-             , p.position_x AS placement_position_x
-             , p.position_y AS placement_position_y
-             , ui.id AS user_item_id
+             , b.image_url     AS background_image_url
+             , p.id            AS placement_id
+             , p.position_x    AS placement_position_x
+             , p.position_y    AS placement_position_y
+             , ui.id           AS user_item_id
              , ui.placed_count
-             , i.id AS item_id
-             , i.name AS item_name
-             , i.image_url AS item_image_url
-          FROM forest f
-          LEFT JOIN background b ON f.background_id = b.id
-          LEFT JOIN user_item ui ON ui.forest_id = f.id AND ui.placed_count > 0
-          LEFT JOIN placement p ON p.user_item_id = ui.id
-          LEFT JOIN item i ON ui.item_id = i.id
-         WHERE f.id = #{forestId}
-           AND (f.is_public = true
+             , i.id            AS item_id
+             , i.name          AS item_name
+             , i.image_url     AS item_image_url
+        FROM forest f
+                 LEFT JOIN background b ON f.background_id = b.id
+                 LEFT JOIN user_item ui ON ui.forest_id = f.id AND ui.placed_count > 0
+                 LEFT JOIN placement p ON p.user_item_id = ui.id
+                 LEFT JOIN item i ON ui.item_id = i.id
+        WHERE f.id = #{forestId}
+          AND (f.is_public = true
             OR (f.is_public = false AND f.user_id = #{userId}));
     </select>
 </mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #79 

## ✅ 작업 사항
- 기존 기록의 조각 조회시 유저가 가진 모든 기록의 조각이 조회되는 것을 숲 id 별로 조회 가능하게 수정하였습니다 ! 

## 📸 스크린샷 (선택)
<img width="509" alt="image" src="https://github.com/user-attachments/assets/b834d35b-e764-4f5b-a23a-0dd84559c8e4" />

<img width="687" alt="image" src="https://github.com/user-attachments/assets/396c7f72-8fbb-4d2c-b3da-3a6a81f8d0ae" />


## 👩‍💻 공유 포인트 및 논의 사항
