### PR TITLE
🌟 feat: 감정의 숲 날짜별, 월별 일기조회 기능추가

### DIFF
--- a/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/controller/QueryForestEmotionController.java
@@ -1,10 +1,7 @@
 package com.x1.groo.forest.emotion.query.controller;
 
 import com.x1.groo.common.JwtUtil;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
+import com.x1.groo.forest.emotion.query.dto.*;
 import com.x1.groo.forest.emotion.query.service.QueryForestEmotionService;
 import io.jsonwebtoken.Claims;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -90,5 +88,38 @@ public class QueryForestEmotionController {
 
         List<QueryForestEmotionDetailDTO> result = queryForestEmotionService.getForestDetail(userId, forestId);
         return ResponseEntity.ok(result);
+    }
+
+    /* 날짜별 일기 조회 */
+    @GetMapping("/diary/{forestId}/date")
+    public ResponseEntity<List<QueryForestEmotionDiaryByDateDTO>> getDiariesByDate(
+            @RequestHeader(value = "Authorization") String authorizationHeader,
+            @PathVariable int forestId,
+            @RequestParam LocalDate date
+    ) {
+        // JWT에서 userId 추출
+        String token = authorizationHeader.replace("Bearer", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        // 서비스 호출
+        List<QueryForestEmotionDiaryByDateDTO> diaries = queryForestEmotionService.findDiaries(userId, forestId, date);
+        return ResponseEntity.ok(diaries);
+    }
+
+    /* 월별 일기 조회 */
+    @GetMapping("/diary/{forestId}/month")
+    public ResponseEntity<List<QueryForestEmotionDiaryByMonthDTO>> getDiariesByMonth(
+            @RequestHeader(value = "Authorization") String authorizationHeader,
+            @PathVariable int forestId,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        String token = authorizationHeader.replace("Bearer", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        List<QueryForestEmotionDiaryByMonthDTO> diaries = queryForestEmotionService.findDiariesByMonth(userId, forestId, year, month);
+        return ResponseEntity.ok(diaries);
     }
 }

--- a/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDiaryByDateDTO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDiaryByDateDTO.java
@@ -1,0 +1,18 @@
+package com.x1.groo.forest.emotion.query.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class QueryForestEmotionDiaryByDateDTO {
+    private int diaryId;                // 일기 ID (감정 매핑용)
+    private String content;             // 일기의 내용
+    private LocalDateTime createdAt;    // 일기 작성 날짜 + 시간
+    private List<String> emotions;      // 감정 리스트
+}

--- a/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDiaryByMonthDTO.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/dto/QueryForestEmotionDiaryByMonthDTO.java
@@ -1,0 +1,15 @@
+package com.x1.groo.forest.emotion.query.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class QueryForestEmotionDiaryByMonthDTO {
+    private int diaryId;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.java
@@ -1,12 +1,10 @@
 package com.x1.groo.forest.emotion.query.repository;
 
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
+import com.x1.groo.forest.emotion.query.dto.*;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper
@@ -32,6 +30,28 @@ public interface QueryForestEmotionMapper {
     );
 
     List<QueryForestEmotionDetailDTO> findForestDetail(
+            @Param("userId") int userId,
+            @Param("forestId") int forestId
+    );
+
+    List<QueryForestEmotionDiaryByDateDTO> findDiaryByDateAndForestId(
+            @Param("forestId") int forestId,
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
+
+    List<QueryForestEmotionDiaryByMonthDTO> findDiariesByMonth(
+            @Param("forestId") int forestId,
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime
+    );
+
+    Boolean existsUserInForest(
+            @Param("userId") int userId,
+            @Param("forestId") int forestId
+    );
+
+    Boolean isOwnerOfForest(
             @Param("userId") int userId,
             @Param("forestId") int forestId
     );

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionService.java
@@ -1,11 +1,9 @@
 package com.x1.groo.forest.emotion.query.service;
 
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
+import com.x1.groo.forest.emotion.query.dto.*;
 import org.springframework.security.access.AccessDeniedException;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface QueryForestEmotionService {
@@ -16,5 +14,9 @@ public interface QueryForestEmotionService {
     List<QueryForestEmotionMailboxDTO> getMailboxDetail(int userId, int id);
 
     List<QueryForestEmotionDetailDTO> getForestDetail(int userId, int forestId);
+
+    List<QueryForestEmotionDiaryByDateDTO> findDiaries(int userId, int forestId, LocalDate date);
+
+    List<QueryForestEmotionDiaryByMonthDTO> findDiariesByMonth(int userId, int forestId, int year, int month);
 }
 

--- a/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/emotion/query/service/QueryForestEmotionServiceImpl.java
@@ -1,14 +1,13 @@
 package com.x1.groo.forest.emotion.query.service;
 
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDetailDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionMailboxListDTO;
-import com.x1.groo.forest.emotion.query.dto.QueryForestEmotionUserItemDTO;
+import com.x1.groo.forest.emotion.query.dto.*;
 import com.x1.groo.forest.emotion.query.repository.QueryForestEmotionMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -38,6 +37,43 @@ public class QueryForestEmotionServiceImpl implements QueryForestEmotionService 
 
     public List<QueryForestEmotionDetailDTO> getForestDetail(int userId, int forestId) {
         return queryForestEmotionMapper.findForestDetail(userId, forestId);
+    }
+
+    // 날짜별 일기 조회
+    @Override
+    public List<QueryForestEmotionDiaryByDateDTO> findDiaries(int userId, int forestId, LocalDate date) {
+
+        boolean isOwner = queryForestEmotionMapper.isOwnerOfForest(userId, forestId);
+        boolean isShared = queryForestEmotionMapper.existsUserInForest(userId, forestId);
+
+        if (!(isOwner || isShared)) {
+            throw new AccessDeniedException("해당 숲에 대한 접근 권한이 없습니다.");
+        }
+
+        // 날짜 범위 생성
+        LocalDateTime startDateTime = date.atStartOfDay();      // 00:00:00
+        LocalDateTime endDateTime = date.atTime(23, 59, 59);    // 23:59:59
+
+        // 일기 리스트 조회
+        return queryForestEmotionMapper.findDiaryByDateAndForestId(forestId, startDateTime, endDateTime);
+    }
+
+    // 월 별 일기 조회
+    @Override
+    public List<QueryForestEmotionDiaryByMonthDTO> findDiariesByMonth(int userId, int forestId, int year, int month) {
+        boolean isOwner = queryForestEmotionMapper.isOwnerOfForest(userId, forestId);
+        boolean isShared = queryForestEmotionMapper.existsUserInForest(userId, forestId);
+
+        if (!(isOwner || isShared)) {
+            throw new AccessDeniedException("해당 숲에 대한 접근 권한이 없습니다.");
+        }
+
+        LocalDateTime startDateTime = LocalDate.of(year, month, 1).atStartOfDay();
+        LocalDateTime endDateTime = startDateTime
+                .withDayOfMonth(startDateTime.toLocalDate().lengthOfMonth())
+                .withHour(23).withMinute(59).withSecond(59);
+
+        return queryForestEmotionMapper.findDiariesByMonth(forestId, startDateTime, endDateTime);
     }
 
 }

--- a/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
+++ b/src/main/resources/com/x1/groo/forest/emotion/query/repository/QueryForestEmotionMapper.xml
@@ -52,6 +52,18 @@
         <result property="itemImageUrl" column="item_image_url"/>
     </resultMap>
 
+    <resultMap id="DiaryWithEmotionResultMap" type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDiaryByDateDTO">
+        <id property="diaryId" column="diary_id"/>
+        <result property="content" column="content"/>
+        <result property="createdAt" column="created_at"/>
+        <collection property="emotions" ofType="string" column="diary_id" select="findEmotionsByDiaryId"/>
+    </resultMap>
+
+    <resultMap id="DiaryByMonthResultMap" type="com.x1.groo.forest.emotion.query.dto.QueryForestEmotionDiaryByMonthDTO">
+        <id property="diaryId" column="id"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
     <select id="findUserIdByForestId" resultType="int">
         SELECT user_id
         FROM forest
@@ -125,4 +137,48 @@
           AND (f.is_public = true
             OR (f.is_public = false AND f.user_id = #{userId}));
     </select>
+
+    <select id="findDiaryByDateAndForestId" resultMap="DiaryWithEmotionResultMap">
+        SELECT DISTINCT
+            d.id AS diary_id
+                      , d.content
+                      , d.created_at
+        FROM diary d
+                 JOIN user u ON d.user_id = u.id
+                 JOIN forest f ON d.forest_id = f.id
+                 LEFT JOIN shared_forest sf ON f.id = sf.forest_id
+        WHERE f.id = #{forestId}
+          AND d.is_published = 1
+          AND d.created_at BETWEEN #{startDateTime} AND #{endDateTime}
+    </select>
+
+    <select id="findDiariesByMonth" resultMap="DiaryByMonthResultMap">
+        SELECT
+            d.id
+             , d.created_at
+        FROM diary d
+        WHERE d.forest_id = #{forestId}
+          AND d.is_published = 1
+          AND d.created_at BETWEEN #{startDateTime} AND #{endDateTime}
+    </select>
+
+    <select id="isOwnerOfForest" resultType="boolean">
+        SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+        FROM forest
+        WHERE id = #{forestId} AND user_id = #{userId}
+    </select>
+
+    <select id="existsUserInForest" resultType="boolean">
+        SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+        FROM shared_forest
+        WHERE user_id = #{userId}
+          AND forest_id = #{forestId}
+    </select>
+
+    <select id="findEmotionsByDiaryId" resultType="string">
+        SELECT emotion
+        FROM diary_emotion
+        WHERE diary_id = #{diary_id}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #64 

## ✅ 작업 사항
<br>
감정의 숲에 날짜별, 월별 일기조회 기능 추가하였습니다.

## 📸 스크린샷 (선택)
<br>

감정의 숲 날짜별 일기 조회
![image](https://github.com/user-attachments/assets/32892141-2ca9-4176-814a-3098b1304e65)

감정의 숲 월 별 일기 조회

![image](https://github.com/user-attachments/assets/7e9c0c4d-30b0-4e30-aa39-bc018030a3c5)


## 👩‍💻 공유 포인트 및 논의 사항
