### PR TITLE
🚑 fix: 우정의 숲 상세조회 오류 수정

### DIFF
--- a/src/main/java/com/x1/groo/forest/mate/query/dao/MateMapper.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/dao/MateMapper.java
@@ -29,7 +29,7 @@ public interface MateMapper {
             @Param("userId") int userId
     );
 
-    List<MateForestDetailDTO> findForestDetail(
+    MateForestDetailDTO findForestDetail(
             @Param("forestId") int forestId
     );
 

--- a/src/main/java/com/x1/groo/forest/mate/query/service/MateService.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/service/MateService.java
@@ -15,5 +15,5 @@ public interface MateService {
 
     List<MateForestResponseDTO> getForestsByUserId(int userId);
 
-    List<MateForestDetailDTO> getForestDetail(int forestId);
+    MateForestDetailDTO getForestDetail(int forestId);
 }

--- a/src/main/java/com/x1/groo/forest/mate/query/service/MateServiceImpl.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/service/MateServiceImpl.java
@@ -5,6 +5,7 @@ import com.x1.groo.forest.mate.query.dto.DiaryByDateDTO;
 import com.x1.groo.forest.mate.query.dto.DiaryByMonthDTO;
 import com.x1.groo.forest.mate.query.dto.MateForestDetailDTO;
 import com.x1.groo.forest.mate.query.dto.MateForestResponseDTO;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
@@ -57,16 +58,20 @@ public class MateServiceImpl implements MateService {
     }
 
     @Override
-    public List<MateForestDetailDTO> getForestDetail(int forestId) {
-        List<MateForestDetailDTO> forestDetails = mateMapper.findForestDetail(forestId);
+    public MateForestDetailDTO getForestDetail(int forestId) {
+        MateForestDetailDTO forestDetails = mateMapper.findForestDetail(forestId);
+
+        if (forestDetails == null) {
+            log.error("Forest with id {} not found", forestId);
+            throw new EntityNotFoundException("해당 숲을 찾을 수 없습니다: id = " + forestId);
+        }
+
 
         List<String> nicknames = mateMapper.findNicknamesByForestId(forestId);
 
-        log.info(nicknames.toString());
-        for (MateForestDetailDTO detail : forestDetails) {
-            detail.setNicknames(nicknames);
-        }
+        forestDetails.setNicknames(nicknames);
 
+        log.info(forestDetails.toString());
         return forestDetails;
     }
 

--- a/src/main/resources/com/x1/groo/forest/mate/query/dao/MateMapper.xml
+++ b/src/main/resources/com/x1/groo/forest/mate/query/dao/MateMapper.xml
@@ -106,8 +106,8 @@
           LEFT JOIN placement p ON p.user_item_id = ui.id
           LEFT JOIN item i ON ui.item_id = i.id
          WHERE f.id = #{forestId}
-           AND f.is_public = true
-           AND p.id IS NOT NULL;
+<!--           AND f.is_public = false-->
+<!--           AND p.id IS NOT NULL;-->
     </select>
     
     <!-- 숲에 참여한 모든 유저 닉네임 조회 -->


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #88 

## ✅ 작업 사항
우정의 숲 상세조회를 할때 빈 객체로 나오는 상황이 발생하여 쿼리문을 수정하였습니다.
<br>

## 📸 스크린샷 
<img width="1440" alt="스크린샷 2025-05-01 14 15 01" src="https://github.com/user-attachments/assets/7a6cd051-2099-476a-b22d-d17781239859" />

<br>

## 👩‍💻 공유 포인트 및 논의 사항
