### PR TITLE
🌟 feat: 숲 이름 변경하기 구현

### DIFF
--- a/src/main/java/com/x1/groo/forest/emotion/command/application/controller/CommandEmotionForestController.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/application/controller/CommandEmotionForestController.java
@@ -5,15 +5,14 @@ import com.x1.groo.forest.emotion.command.application.service.CommandEmotionFore
 import com.x1.groo.forest.emotion.command.domain.vo.RequestCreateVO;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestMailboxVO;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestPlacementVO;
-import com.x1.groo.forest.emotion.command.domain.vo.RequestPublicVO;
 import com.x1.groo.forest.emotion.command.domain.vo.RequestReplacementVO;
-import com.x1.groo.forest.mate.command.domain.vo.CreateMateForestRequest;
 import io.jsonwebtoken.Claims;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/emotion-forest")
@@ -32,7 +31,7 @@ public class CommandEmotionForestController {
 
     @DeleteMapping("/placement")
     public ResponseEntity<Void> retrieveItemById(@RequestHeader(value = "Authorization") String authorizationHeader,
-                                                @RequestParam int placementId) {
+                                                 @RequestParam int placementId) {
 
         // "Bearer " 부분 제거
         String token = authorizationHeader.replace("Bearer", "").trim();
@@ -46,7 +45,7 @@ public class CommandEmotionForestController {
 
     @DeleteMapping("/placements")
     public ResponseEntity<Void> retrieveAllItems(@RequestHeader(value = "Authorization") String authorizationHeader,
-                                                @RequestParam int forestId) {
+                                                 @RequestParam int forestId) {
 
         // "Bearer " 부분 제거
         String token = authorizationHeader.replace("Bearer", "").trim();
@@ -87,8 +86,8 @@ public class CommandEmotionForestController {
     }
 
     @PostMapping("/mailbox")
-    public ResponseEntity<Void> createMailbox (@RequestHeader(value = "Authorization") String authorizationHeader,
-                                               @RequestBody RequestMailboxVO requestMailboxVO) {
+    public ResponseEntity<Void> createMailbox(@RequestHeader(value = "Authorization") String authorizationHeader,
+                                              @RequestBody RequestMailboxVO requestMailboxVO) {
 
         // "Bearer " 부분 제거
         String token = authorizationHeader.replace("Bearer", "").trim();
@@ -101,9 +100,9 @@ public class CommandEmotionForestController {
     }
 
     @DeleteMapping("/mailbox")
-    public ResponseEntity<Void> deleteMailbox (@RequestHeader(value = "Authorization") String authorizationHeader,
-                                               @RequestParam int mailboxId,
-                                               @RequestParam int forestId) {
+    public ResponseEntity<Void> deleteMailbox(@RequestHeader(value = "Authorization") String authorizationHeader,
+                                              @RequestParam int mailboxId,
+                                              @RequestParam int forestId) {
 
         // "Bearer " 부분 제거
         String token = authorizationHeader.replace("Bearer", "").trim();
@@ -143,6 +142,22 @@ public class CommandEmotionForestController {
         commandEmotionForestService.createEmotionForest(userId, request);
 
         return ResponseEntity.ok(Map.of("message", "감정의 숲이 생성되었습니다."));
+    }
+
+    // 숲 이름 수정하기
+    @PatchMapping("/{forestId}/name")
+    public ResponseEntity<Void> updateForestName(@PathVariable int forestId,
+                                                 @RequestHeader(value = "Authorization") String authorizationHeader,
+                                                 @RequestBody Map<String, String> request) {
+        String token = authorizationHeader.replace("Bearer", "").trim();
+        Claims claims = jwtUtil.parseJwt(token);
+        int userId = ((Number) claims.get("userId")).intValue();
+
+        String newName = request.get("name");
+
+        commandEmotionForestService.updateForestName(forestId, userId, newName);
+
+        return ResponseEntity.ok().build();
     }
 
 

--- a/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestService.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/application/service/CommandEmotionForestService.java
@@ -21,4 +21,6 @@ public interface CommandEmotionForestService {
     void updateForestPublic(int forestId, int userId);
 
     void createEmotionForest(int userId, RequestCreateVO request);
+
+    void updateForestName(int forestId, int userId, String newName);
 }

--- a/src/main/java/com/x1/groo/forest/emotion/command/domain/repository/ForestRepository.java
+++ b/src/main/java/com/x1/groo/forest/emotion/command/domain/repository/ForestRepository.java
@@ -2,10 +2,16 @@ package com.x1.groo.forest.emotion.command.domain.repository;
 
 import com.x1.groo.forest.emotion.command.domain.aggregate.ForestEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ForestRepository extends JpaRepository<ForestEntity, Integer> {
 
     boolean existsByIdAndUserId(int id, int userId);
+
+    // 공유된 숲에 userId가 속해 있는지 여부 확인
+    @Query("SELECT COUNT(sf) > 0 FROM SharedForestEntity sf WHERE sf.userId = :userId AND sf.forestId = :forestId")
+    boolean isUserInSharedForest(@Param("userId") int userId, @Param("forestId") int forestId);
 }

--- a/src/main/java/com/x1/groo/forest/mate/query/controller/MateController.java
+++ b/src/main/java/com/x1/groo/forest/mate/query/controller/MateController.java
@@ -70,7 +70,7 @@ public class MateController {
 
     /* 우정의 숲 상세 조회 */
     @GetMapping("/detail/{forestId}")
-    public List<MateForestDetailDTO> getForestDetail(@PathVariable int forestId) {
+    public MateForestDetailDTO getForestDetail(@PathVariable int forestId) {
 
         return mateService.getForestDetail(forestId);
     }


### PR DESCRIPTION
## 🧩 이슈 번호 

- close #이슈번호

## ✅ 작업 사항
- MateController의 우정의 숲 상세 조회에서 오류 나는 부분 수정하였습니다

- 감정의 숲, 우정의 숲에서 숲 이름 변경하는 로직 구현하였습니다 !
- 우정의 숲에서는 참여중인 유저 모두 숲 이름을 변경할 수 있습니다.

## 📸 스크린샷 (선택)
<br>

## 👩‍💻 공유 포인트 및 논의 사항
